### PR TITLE
fix: resolve Dockerfile package manager compatibility issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV PHP_EXT_pgsql=1
 ENV PHP_EXT_pdo_pgsql=1
 
 # Install supervisord and netcat for health checks
-RUN apk add --no-cache supervisor netcat-openbsd
+RUN apt-get update && apt-get install -y supervisor netcat-openbsd && rm -rf /var/lib/apt/lists/*
 
 # Create supervisor log directory
 RUN mkdir -p /var/log/supervisor


### PR DESCRIPTION
## Description
Fixes a Docker build failure where the Dockerfile was using Alpine's \`apk\` package manager in a Debian-based image.

## Changes Made
- **Dockerfile**: Changed package installation from \`apk add\` to \`apt-get install\` in the production stage
- **Package Manager**: Updated to use \`apt-get\` instead of \`apk\` since the base image \`ghcr.io/juniyadi/php-base:8.5\` is Debian/Ubuntu-based
- **Cleanup**: Added proper apt cache cleanup to reduce image size

## Issue Fixed
The Docker build was failing with:
```
/bin/sh: 1: apk: not found
```

This occurred because the production stage was trying to use Alpine's package manager in a Debian-based container.

## Testing
- Docker build should now complete successfully
- Supervisor and netcat packages will install correctly
- Image size remains optimized with cache cleanup