### PR TITLE
refactor: switch from schedule:work to crond for Laravel scheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,8 @@ ENV PHP_EXT_bcmath=1
 ENV PHP_EXT_pgsql=1
 ENV PHP_EXT_pdo_pgsql=1
 
-# Install supervisord and netcat for health checks
-RUN apt-get update && apt-get install -y supervisor netcat-openbsd && rm -rf /var/lib/apt/lists/*
-
-# Create supervisor log directory
-RUN mkdir -p /var/log/supervisor
+# Install supervisord, cron, and netcat for health checks
+RUN apt-get update && apt-get install -y supervisor cron netcat-openbsd && rm -rf /var/lib/apt/lists/*
 
 # Copy built application from builder
 COPY --from=builder --chown=www-data:www-data /app /var/www/html
@@ -72,6 +69,10 @@ COPY docker/nginx/default.conf /etc/nginx/http.d/default.conf
 
 # Copy supervisord configuration
 COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Copy crontab file
+COPY docker/crontab /etc/cron.d/laravel
+RUN chmod 0644 /etc/cron.d/laravel && crontab /etc/cron.d/laravel
 
 # Copy entrypoint script
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,0 +1,3 @@
+# Laravel Scheduler - runs every minute
+# Output is redirected to supervisor's stdout for Docker logging
+* * * * * www-data cd /var/www/html && php artisan schedule:run >> /proc/1/fd/1 2>&1

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -24,7 +24,6 @@ mkdir -p /var/www/html/storage/framework/sessions
 mkdir -p /var/www/html/storage/framework/views
 mkdir -p /var/www/html/storage/logs
 mkdir -p /var/www/html/bootstrap/cache
-mkdir -p /var/log/supervisor
 
 # Fix permissions for writable directories
 chmod -R 775 /var/www/html/storage /var/www/html/bootstrap/cache || true
@@ -79,7 +78,7 @@ fi
 echo "Starting Laravel Marketing Mail..."
 echo "  - PHP-FPM on unix socket"
 echo "  - Nginx on port 80"
-echo "  - Laravel Scheduler (every minute)"
+echo "  - Cron (Laravel Scheduler runs every minute)"
 echo "  - Laravel Queue Worker"
 
 exec "$@"

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,37 +1,39 @@
 [supervisord]
 nodaemon=true
 user=root
-logfile=/var/log/supervisor/supervisord.log
+logfile=/dev/stdout
+logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
-logfile_maxbytes=50MB
-logfile_backups=10
 loglevel=info
 
 [program:php-fpm]
 command=php-fpm -F
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/supervisor/php-fpm.err.log
-stdout_logfile=/var/log/supervisor/php-fpm.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 priority=10
 
 [program:nginx]
 command=nginx -g "daemon off;"
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/supervisor/nginx.err.log
-stdout_logfile=/var/log/supervisor/nginx.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 priority=20
 
-[program:scheduler]
-command=php /var/www/html/artisan schedule:work --verbose
-directory=/var/www/html
+[program:cron]
+command=cron -f
 autostart=true
 autorestart=true
-user=www-data
-stderr_logfile=/var/log/supervisor/scheduler.err.log
-stdout_logfile=/var/log/supervisor/scheduler.out.log
-stopwaitsecs=3600
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 priority=30
 
 [program:queue]
@@ -40,7 +42,9 @@ directory=/var/www/html
 autostart=true
 autorestart=true
 user=www-data
-stderr_logfile=/var/log/supervisor/queue.err.log
-stdout_logfile=/var/log/supervisor/queue.out.log
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 stopwaitsecs=3600
 priority=40


### PR DESCRIPTION
## Summary

Switch from Laravel's `schedule:work` command to traditional `crond` for running the Laravel scheduler in Docker containers.

## Changes

- **Dockerfile**: Add `cron` package installation and configure crontab
- **docker/crontab** (NEW): Cron job running Laravel scheduler every minute
- **docker/supervisord.conf**: Replace `schedule:work` with `cron -f` and redirect all logs to stdout/stderr
- **docker/docker-entrypoint.sh**: Update startup message and remove log directory creation

## Key Improvements

- ✅ Cron runs every minute as expected
- ✅ All logs now go to stdout/stderr (Docker-friendly, no file persistence)
- ✅ Traditional cron daemon approach instead of continuous PHP process
- ✅ Better container logging visibility

## Testing

Build and run the container:
```bash
docker-compose build
docker-compose up
```

Verify cron is running and scheduler executes every minute in Docker logs.