### PR TITLE
docs: reorganize kubernetes deployment files into docs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ aws iam put-user-policy \
 
 #### For Kubernetes/EKS (IAM Role with IRSA)
 
-See the [Kubernetes Deployment Guide](kubernetes/README.md) for complete IRSA setup instructions.
+See the [Kubernetes Deployment Guide](docs/kubernetes/README.md) for complete IRSA setup instructions.
 
 ### Step 3: Configure Application
 
@@ -648,7 +648,7 @@ eksctl create cluster \
 # 3. Update Kubernetes manifests with your configuration
 # 4. Deploy to cluster
 
-kubectl apply -f kubernetes/
+kubectl apply -f docs/kubernetes/
 ```
 
 ### Full Documentation
@@ -661,7 +661,7 @@ For complete step-by-step instructions including:
 - DNS configuration
 - Monitoring and troubleshooting
 
-**See: [Kubernetes Deployment Guide](kubernetes/README.md)**
+**See: [Kubernetes Deployment Guide](docs/kubernetes/README.md)**
 
 ### Architecture
 

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -1,0 +1,556 @@
+# Kubernetes Deployment Guide for AWS EKS
+
+This guide explains how to deploy Laravel Marketing Mail on AWS EKS using IAM Roles for Service Accounts (IRSA) for secure AWS service access.
+
+## Overview
+
+This deployment uses:
+- **AWS EKS** - Managed Kubernetes cluster
+- **IRSA** - IAM Roles for Service Accounts (no hardcoded credentials)
+- **AWS S3** - File storage for email template images
+- **AWS SES** - Email sending
+- **AWS SNS** - Email event tracking webhooks
+- **AWS Load Balancer Controller** - Ingress management
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         AWS EKS Cluster                      │
+│                                                              │
+│  ┌────────────────┐  ┌────────────────┐  ┌──────────────┐  │
+│  │   App Pods     │  │  Queue Worker  │  │  Scheduler   │  │
+│  │  (replicas: 2) │  │  (replicas: 1) │  │ (replicas: 1)│  │
+│  └────────┬───────┘  └────────┬───────┘  └──────┬───────┘  │
+│           │                   │                  │          │
+│           └───────────────────┴──────────────────┘          │
+│                              │                              │
+│                    ┌─────────▼──────────┐                   │
+│                    │  ServiceAccount    │                   │
+│                    │  (IRSA enabled)    │                   │
+│                    └─────────┬──────────┘                   │
+└──────────────────────────────┼───────────────────────────────┘
+                               │
+                    ┌──────────▼──────────┐
+                    │   IAM Role (IRSA)   │
+                    │  - S3 Policy        │
+                    │  - SES Policy       │
+                    └──────────┬──────────┘
+                               │
+          ┌────────────────────┼────────────────────┐
+          │                    │                    │
+    ┌─────▼────┐        ┌──────▼─────┐      ┌──────▼─────┐
+    │  AWS S3  │        │  AWS SES   │      │  AWS SNS   │
+    │  Bucket  │        │  (Emails)  │      │ (Webhooks) │
+    └──────────┘        └────────────┘      └────────────┘
+```
+
+## Prerequisites
+
+### 1. AWS CLI & eksctl
+```bash
+# Install AWS CLI
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+
+# Install eksctl
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+sudo mv /tmp/eksctl /usr/local/bin
+
+# Configure AWS credentials
+aws configure
+```
+
+### 2. kubectl
+```bash
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+```
+
+### 3. Helm (for AWS Load Balancer Controller)
+```bash
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+```
+
+---
+
+## Step 1: Create EKS Cluster
+
+### Option A: Using eksctl (Recommended)
+
+```bash
+# Create cluster with OIDC provider enabled (required for IRSA)
+eksctl create cluster \
+  --name marketing-mail-cluster \
+  --region us-east-1 \
+  --nodegroup-name standard-workers \
+  --node-type t3.medium \
+  --nodes 2 \
+  --nodes-min 2 \
+  --nodes-max 4 \
+  --with-oidc \
+  --managed
+```
+
+### Option B: Using existing cluster
+
+```bash
+# Associate OIDC provider with existing cluster
+eksctl utils associate-iam-oidc-provider \
+  --cluster marketing-mail-cluster \
+  --region us-east-1 \
+  --approve
+```
+
+---
+
+## Step 2: Install AWS Load Balancer Controller
+
+```bash
+# Add EKS Helm repo
+helm repo add eks https://aws.github.io/eks-charts
+helm repo update
+
+# Create IAM policy for load balancer controller
+curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.7.0/docs/install/iam_policy.json
+
+aws iam create-policy \
+  --policy-name AWSLoadBalancerControllerIAMPolicy \
+  --policy-document file://iam_policy.json
+
+# Create IAM role for service account
+eksctl create iamserviceaccount \
+  --cluster=marketing-mail-cluster \
+  --namespace=kube-system \
+  --name=aws-load-balancer-controller \
+  --attach-policy-arn=arn:aws:iam::ACCOUNT_ID:policy/AWSLoadBalancerControllerIAMPolicy \
+  --override-existing-serviceaccounts \
+  --region us-east-1 \
+  --approve
+
+# Install controller
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+  -n kube-system \
+  --set clusterName=marketing-mail-cluster \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=aws-load-balancer-controller
+```
+
+---
+
+## Step 3: Create S3 Bucket
+
+```bash
+# Create S3 bucket
+aws s3 mb s3://marketing-mail-storage --region us-east-1
+
+# Enable versioning (optional but recommended)
+aws s3api put-bucket-versioning \
+  --bucket marketing-mail-storage \
+  --versioning-configuration Status=Enabled
+
+# Set CORS policy for direct uploads (if needed)
+cat > cors.json << 'EOF'
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["https://marketing.yourdomain.com"],
+      "AllowedMethods": ["GET", "PUT", "POST", "DELETE"],
+      "AllowedHeaders": ["*"],
+      "MaxAgeSeconds": 3000
+    }
+  ]
+}
+EOF
+
+aws s3api put-bucket-cors \
+  --bucket marketing-mail-storage \
+  --cors-configuration file://cors.json
+```
+
+---
+
+## Step 4: Create IAM Role for IRSA
+
+### 4.1 Get OIDC Provider URL
+
+```bash
+# Get OIDC provider URL
+aws eks describe-cluster \
+  --name marketing-mail-cluster \
+  --query "cluster.identity.oidc.issuer" \
+  --output text
+
+# Output example: https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE
+```
+
+### 4.2 Create IAM Policy
+
+```bash
+# Create IAM policy for S3 and SES access
+cat > marketing-mail-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3BucketAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::marketing-mail-storage",
+        "arn:aws:s3:::marketing-mail-storage/*"
+      ]
+    },
+    {
+      "Sid": "SESEmailSending",
+      "Effect": "Allow",
+      "Action": [
+        "ses:SendEmail",
+        "ses:SendRawEmail",
+        "ses:GetSendQuota",
+        "ses:GetSendStatistics"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+aws iam create-policy \
+  --policy-name MarketingMailEKSPolicy \
+  --policy-document file://marketing-mail-policy.json
+```
+
+### 4.3 Create IAM Role with Trust Policy
+
+```bash
+# Get your AWS account ID
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+# Get OIDC provider (without https://)
+OIDC_PROVIDER=$(aws eks describe-cluster --name marketing-mail-cluster --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
+
+# Create trust policy
+cat > trust-policy.json << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "${OIDC_PROVIDER}:sub": "system:serviceaccount:marketing-mail:marketing-mail-sa",
+          "${OIDC_PROVIDER}:aud": "sts.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+# Create IAM role
+aws iam create-role \
+  --role-name marketing-mail-eks-pod-role \
+  --assume-role-policy-document file://trust-policy.json
+
+# Attach policy to role
+aws iam attach-role-policy \
+  --role-name marketing-mail-eks-pod-role \
+  --policy-arn arn:aws:iam::${ACCOUNT_ID}:policy/MarketingMailEKSPolicy
+```
+
+---
+
+## Step 5: Configure Kubernetes Manifests
+
+### 5.1 Update ServiceAccount
+
+Edit `docs/kubernetes/serviceaccount.yaml`:
+
+```yaml
+annotations:
+  eks.amazonaws.com/role-arn: arn:aws:iam::YOUR_ACCOUNT_ID:role/marketing-mail-eks-pod-role
+```
+
+### 5.2 Update ConfigMap
+
+Edit `docs/kubernetes/configmap.yaml` with your settings:
+- `APP_URL`
+- `AWS_BUCKET`
+- `AWS_DEFAULT_REGION`
+- `MAIL_FROM_ADDRESS`
+- `ALLOWED_DOMAIN`
+
+### 5.3 Update Secret
+
+Edit `docs/kubernetes/secret.yaml`:
+
+```bash
+# Generate APP_KEY
+php artisan key:generate --show
+
+# Update secret.yaml with:
+# - APP_KEY (from above)
+# - DB_USERNAME
+# - DB_PASSWORD
+# - GOOGLE_CLIENT_ID (if using OAuth)
+# - GOOGLE_CLIENT_SECRET (if using OAuth)
+```
+
+### 5.4 Update Deployment
+
+Edit `docs/kubernetes/deployment.yaml`:
+- Replace `ACCOUNT_ID` with your AWS account ID
+
+### 5.5 Update Ingress
+
+Edit `docs/kubernetes/ingress.yaml`:
+- Replace `ACCOUNT_ID` and `CERTIFICATE_ID` with your ACM certificate ARN
+- Update `host` with your domain
+
+---
+
+## Step 6: Deploy to EKS
+
+```bash
+# Update kubeconfig
+aws eks update-kubeconfig --name marketing-mail-cluster --region us-east-1
+
+# Apply manifests in order
+kubectl apply -f docs/kubernetes/namespace.yaml
+kubectl apply -f docs/kubernetes/configmap.yaml
+kubectl apply -f docs/kubernetes/secret.yaml
+kubectl apply -f docs/kubernetes/serviceaccount.yaml
+kubectl apply -f docs/kubernetes/deployment.yaml
+kubectl apply -f docs/kubernetes/service.yaml
+kubectl apply -f docs/kubernetes/ingress.yaml
+
+# Verify deployment
+kubectl get all -n marketing-mail
+
+# Check IRSA configuration
+kubectl describe sa marketing-mail-sa -n marketing-mail
+
+# Check pod logs
+kubectl logs -n marketing-mail -l app=marketing-mail --tail=50
+```
+
+---
+
+## Step 7: Verify IRSA is Working
+
+```bash
+# Exec into a pod
+kubectl exec -it -n marketing-mail deployment/marketing-mail -- bash
+
+# Inside the pod, check environment variables
+env | grep AWS
+
+# You should see:
+# AWS_ROLE_ARN=arn:aws:iam::ACCOUNT_ID:role/marketing-mail-eks-pod-role
+# AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
+
+# Test S3 access
+php artisan tinker
+>>> Storage::disk('s3')->put('test.txt', 'Hello from EKS with IRSA!');
+>>> Storage::disk('s3')->get('test.txt');
+
+# Test SES access
+>>> Mail::raw('Test email', function($m) { $m->to('test@example.com')->subject('Test'); });
+```
+
+---
+
+## Step 8: DNS Configuration
+
+```bash
+# Get Load Balancer DNS
+kubectl get ingress -n marketing-mail marketing-mail-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+
+# Create CNAME record in your DNS:
+# marketing.yourdomain.com -> <load-balancer-dns-name>
+```
+
+---
+
+## Scaling
+
+### Scale Application Pods
+```bash
+kubectl scale deployment marketing-mail -n marketing-mail --replicas=3
+```
+
+### Scale Queue Workers
+```bash
+kubectl scale deployment marketing-mail-worker -n marketing-mail --replicas=2
+```
+
+### Enable Horizontal Pod Autoscaler
+```bash
+kubectl autoscale deployment marketing-mail \
+  -n marketing-mail \
+  --cpu-percent=70 \
+  --min=2 \
+  --max=10
+```
+
+---
+
+## Monitoring
+
+### View Logs
+```bash
+# App logs
+kubectl logs -f -n marketing-mail -l app=marketing-mail
+
+# Queue worker logs
+kubectl logs -f -n marketing-mail -l app=marketing-mail-worker
+
+# Scheduler logs
+kubectl logs -f -n marketing-mail -l app=marketing-mail-scheduler
+```
+
+### Check Resource Usage
+```bash
+kubectl top pods -n marketing-mail
+kubectl top nodes
+```
+
+---
+
+## Troubleshooting
+
+### IRSA Not Working
+
+```bash
+# Check ServiceAccount annotation
+kubectl describe sa marketing-mail-sa -n marketing-mail | grep role-arn
+
+# Check pod environment
+kubectl exec -n marketing-mail deployment/marketing-mail -- env | grep AWS
+
+# Check IAM role trust policy
+aws iam get-role --role-name marketing-mail-eks-pod-role --query 'Role.AssumeRolePolicyDocument'
+
+# Verify OIDC provider exists
+aws iam list-open-id-connect-providers
+```
+
+### S3 Access Denied
+
+```bash
+# Verify IAM policy attached to role
+aws iam list-attached-role-policies --role-name marketing-mail-eks-pod-role
+
+# Check policy permissions
+aws iam get-policy-version \
+  --policy-arn arn:aws:iam::ACCOUNT_ID:policy/MarketingMailEKSPolicy \
+  --version-id v1
+```
+
+### SES Sending Failures
+
+```bash
+# Check SES sending limits
+aws ses get-send-quota
+
+# Verify domain/email is verified
+aws ses list-identities
+
+# Check if in sandbox mode
+aws ses get-account-sending-enabled
+```
+
+### Load Balancer Not Created
+
+```bash
+# Check ingress events
+kubectl describe ingress -n marketing-mail marketing-mail-ingress
+
+# Check load balancer controller logs
+kubectl logs -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller
+```
+
+---
+
+## Updating the Application
+
+```bash
+# Update image version in deployment.yaml
+# Then apply changes:
+kubectl apply -f docs/kubernetes/deployment.yaml
+
+# Or use kubectl set image:
+kubectl set image deployment/marketing-mail \
+  -n marketing-mail \
+  app=ghcr.io/juniyadi/laravel-marketing-mail:v1.2.0
+
+# Rollout status
+kubectl rollout status deployment/marketing-mail -n marketing-mail
+
+# Rollback if needed
+kubectl rollout undo deployment/marketing-mail -n marketing-mail
+```
+
+---
+
+## Clean Up
+
+```bash
+# Delete all resources
+kubectl delete -f docs/kubernetes/
+
+# Delete cluster
+eksctl delete cluster --name marketing-mail-cluster --region us-east-1
+
+# Delete IAM resources
+aws iam detach-role-policy \
+  --role-name marketing-mail-eks-pod-role \
+  --policy-arn arn:aws:iam::ACCOUNT_ID:policy/MarketingMailEKSPolicy
+
+aws iam delete-role --role-name marketing-mail-eks-pod-role
+aws iam delete-policy --policy-arn arn:aws:iam::ACCOUNT_ID:policy/MarketingMailEKSPolicy
+
+# Delete S3 bucket (after emptying it)
+aws s3 rb s3://marketing-mail-storage --force
+```
+
+---
+
+## Security Best Practices
+
+1. **Use IRSA** - Never hardcode AWS credentials
+2. **Least Privilege** - Grant minimum required IAM permissions
+3. **Network Policies** - Restrict pod-to-pod communication
+4. **Secrets Encryption** - Enable EKS secrets encryption at rest
+5. **Private Subnets** - Deploy worker nodes in private subnets
+6. **Pod Security Standards** - Enable restricted pod security
+7. **Regular Updates** - Keep EKS cluster and nodes updated
+
+---
+
+## Cost Optimization
+
+- Use **Spot Instances** for queue workers (non-critical workloads)
+- Enable **Cluster Autoscaler** to scale nodes based on demand
+- Use **S3 Intelligent-Tiering** for storage cost savings
+- Monitor with **AWS Cost Explorer** to identify optimization opportunities
+
+---
+
+## Support
+
+For issues or questions:
+- **GitHub Issues**: https://github.com/JuniYadi/laravel-marketing-mail/issues
+- **Documentation**: https://github.com/JuniYadi/laravel-marketing-mail

--- a/docs/kubernetes/configmap.yaml
+++ b/docs/kubernetes/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: marketing-mail-config
+  namespace: marketing-mail
+data:
+  APP_NAME: "Laravel Marketing Mail"
+  APP_ENV: "production"
+  APP_DEBUG: "false"
+  APP_URL: "https://marketing.yourdomain.com"
+  
+  LOG_CHANNEL: "stack"
+  LOG_LEVEL: "info"
+  
+  DB_CONNECTION: "mysql"
+  DB_HOST: "mysql-service"
+  DB_PORT: "3306"
+  DB_DATABASE: "marketing_mail"
+  
+  QUEUE_CONNECTION: "redis"
+  CACHE_STORE: "redis"
+  SESSION_DRIVER: "redis"
+  
+  REDIS_HOST: "redis-service"
+  REDIS_PORT: "6379"
+  
+  # AWS Configuration (credentials via IRSA)
+  AWS_DEFAULT_REGION: "us-east-1"
+  AWS_BUCKET: "your-marketing-mail-bucket"
+  
+  # Storage Configuration
+  FILESYSTEM_DISK: "s3"
+  
+  # Mail Configuration
+  MAIL_MAILER: "ses"
+  MAIL_FROM_ADDRESS: "noreply@yourdomain.com"
+  MAIL_FROM_NAME: "Laravel Marketing Mail"
+  
+  # SES Configuration Set (optional)
+  SES_CONFIGURATION_SET: "marketing-emails"
+  
+  # Allowed Sender Domains
+  ALLOWED_DOMAIN: "yourdomain.com"
+  
+  # Authentication Mode
+  AUTH_MODE: "both"

--- a/docs/kubernetes/deployment.yaml
+++ b/docs/kubernetes/deployment.yaml
@@ -1,0 +1,190 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketing-mail
+  namespace: marketing-mail
+  labels:
+    app: marketing-mail
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: marketing-mail
+  template:
+    metadata:
+      labels:
+        app: marketing-mail
+    spec:
+      serviceAccountName: marketing-mail-sa
+      containers:
+      - name: app
+        image: ghcr.io/juniyadi/laravel-marketing-mail:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: marketing-mail-config
+        - secretRef:
+            name: marketing-mail-secret
+        env:
+        # AWS credentials are automatically injected by IRSA
+        # via environment variables and mounted token file
+        - name: AWS_ROLE_ARN
+          value: "arn:aws:iam::ACCOUNT_ID:role/marketing-mail-eks-pod-role"
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        volumeMounts:
+        - name: aws-iam-token
+          mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+          readOnly: true
+      volumes:
+      - name: aws-iam-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: sts.amazonaws.com
+              expirationSeconds: 86400
+              path: token
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketing-mail-worker
+  namespace: marketing-mail
+  labels:
+    app: marketing-mail-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: marketing-mail-worker
+  template:
+    metadata:
+      labels:
+        app: marketing-mail-worker
+    spec:
+      serviceAccountName: marketing-mail-sa
+      containers:
+      - name: queue-worker
+        image: ghcr.io/juniyadi/laravel-marketing-mail:latest
+        imagePullPolicy: Always
+        command: ["php", "artisan", "queue:work"]
+        args:
+        - "--tries=3"
+        - "--timeout=300"
+        - "--sleep=3"
+        - "--max-jobs=1000"
+        - "--max-time=3600"
+        envFrom:
+        - configMapRef:
+            name: marketing-mail-config
+        - secretRef:
+            name: marketing-mail-secret
+        env:
+        - name: AWS_ROLE_ARN
+          value: "arn:aws:iam::ACCOUNT_ID:role/marketing-mail-eks-pod-role"
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "250m"
+        volumeMounts:
+        - name: aws-iam-token
+          mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+          readOnly: true
+      volumes:
+      - name: aws-iam-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: sts.amazonaws.com
+              expirationSeconds: 86400
+              path: token
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketing-mail-scheduler
+  namespace: marketing-mail
+  labels:
+    app: marketing-mail-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: marketing-mail-scheduler
+  template:
+    metadata:
+      labels:
+        app: marketing-mail-scheduler
+    spec:
+      serviceAccountName: marketing-mail-sa
+      containers:
+      - name: scheduler
+        image: ghcr.io/juniyadi/laravel-marketing-mail:latest
+        imagePullPolicy: Always
+        command: ["php", "artisan", "schedule:work"]
+        envFrom:
+        - configMapRef:
+            name: marketing-mail-config
+        - secretRef:
+            name: marketing-mail-secret
+        env:
+        - name: AWS_ROLE_ARN
+          value: "arn:aws:iam::ACCOUNT_ID:role/marketing-mail-eks-pod-role"
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "100m"
+        volumeMounts:
+        - name: aws-iam-token
+          mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+          readOnly: true
+      volumes:
+      - name: aws-iam-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: sts.amazonaws.com
+              expirationSeconds: 86400
+              path: token

--- a/docs/kubernetes/ingress.yaml
+++ b/docs/kubernetes/ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: marketing-mail-ingress
+  namespace: marketing-mail
+  annotations:
+    # AWS Load Balancer Controller annotations
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    
+    # Certificate Manager (replace with your certificate ARN)
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:ACCOUNT_ID:certificate/CERTIFICATE_ID
+    
+    # Health check configuration
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '30'
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
+    alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
+spec:
+  ingressClassName: alb
+  rules:
+  - host: marketing.yourdomain.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: marketing-mail-service
+            port:
+              number: 80

--- a/docs/kubernetes/namespace.yaml
+++ b/docs/kubernetes/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: marketing-mail
+  labels:
+    name: marketing-mail
+    app: laravel-marketing-mail

--- a/docs/kubernetes/secret.yaml
+++ b/docs/kubernetes/secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: marketing-mail-secret
+  namespace: marketing-mail
+type: Opaque
+stringData:
+  # Database Credentials
+  DB_USERNAME: "marketing"
+  DB_PASSWORD: "your-secure-password-here"
+  
+  # Application Key (generate with: php artisan key:generate --show)
+  APP_KEY: "base64:your-generated-app-key-here"
+  
+  # Redis Password (if using authenticated Redis)
+  REDIS_PASSWORD: ""
+  
+  # Google OAuth (optional)
+  GOOGLE_CLIENT_ID: ""
+  GOOGLE_CLIENT_SECRET: ""

--- a/docs/kubernetes/service.yaml
+++ b/docs/kubernetes/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: marketing-mail-service
+  namespace: marketing-mail
+  labels:
+    app: marketing-mail
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: marketing-mail

--- a/docs/kubernetes/serviceaccount.yaml
+++ b/docs/kubernetes/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: marketing-mail-sa
+  namespace: marketing-mail
+  annotations:
+    # Replace with your IAM role ARN for IRSA
+    # Example: arn:aws:iam::123456789012:role/marketing-mail-eks-pod-role
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/marketing-mail-eks-pod-role


### PR DESCRIPTION
This PR reorganizes the kubernetes deployment files for better project structure.

## Changes Made

- **Moved**  directory to  for better organization
- **Updated** all internal references in the kubernetes README.md to reflect new paths
- **Updated** main README.md links to point to the new kubernetes location
- **Maintained** all deployment functionality while improving documentation structure

## Files Affected

-  - Updated all path references
-  - Updated links to kubernetes documentation
- Moved all kubernetes manifest files from root to 

This change improves the project's documentation organization by placing deployment-related files in the docs directory alongside other documentation.