### PR TITLE
fix(gallery): prevent black native file-button in uploader

### DIFF
--- a/resources/views/pages/gallery/⚡index.blade.php
+++ b/resources/views/pages/gallery/⚡index.blade.php
@@ -106,7 +106,7 @@ new class extends Component {
                         x-ref="files"
                         type="file"
                         multiple
-                        class="block rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-900"
+                        class="block rounded-md border border-zinc-300 px-3 py-2 text-sm file:me-3 file:rounded-md file:border-0 file:bg-zinc-100 file:px-3 file:py-2 file:text-sm file:font-medium file:text-zinc-700 hover:file:bg-zinc-200 dark:border-zinc-600 dark:bg-zinc-900 dark:file:bg-zinc-700 dark:file:text-zinc-100 dark:hover:file:bg-zinc-600"
                         accept="image/jpeg,image/png,image/webp,image/gif,image/svg+xml,application/pdf"
                     />
 

--- a/tests/Feature/GalleryPageTest.php
+++ b/tests/Feature/GalleryPageTest.php
@@ -17,6 +17,8 @@ it('shows gallery page and sidebar item for authenticated users', function (): v
         ->assertSee(route('gallery.index'), false)
         ->assertSee('data-max-size-bytes="'.PresignGalleryAssetsRequest::MAX_FILE_SIZE_BYTES.'"', false)
         ->assertSee('application/pdf')
+        ->assertSee('file:bg-zinc-100')
+        ->assertSee('dark:file:bg-zinc-700')
         ->assertDontSee('S3 public base URL is not configured');
 });
 


### PR DESCRIPTION
## Summary
- fix gallery file input by styling the native file-selector button (`file:*` utilities) so it no longer appears black
- keep existing upload action button text behavior from previous fix
- add regression assertion in GalleryPageTest for the file button classes

## Why
The black button is from the browser-native file input button, not the Flux upload button.

## Test
- ./vendor/bin/pint --test
- php artisan test --compact tests/Feature/GalleryPageTest.php
- php artisan test --compact tests/Feature/GalleryAssetApiTest.php
